### PR TITLE
secure login WIP

### DIFF
--- a/secured_nest_page.R
+++ b/secured_nest_page.R
@@ -1,0 +1,8 @@
+current_nest_page <- function(df) {
+  renderUI({
+    fluidPage(
+      auth_ui("auth"),
+      verbatimTextOutput("res_auth")
+    )
+  })
+  }


### PR DESCRIPTION
To do list for completing this.

- [ ] hide usernames on file, hashed? They are currently plain text.
- [ ] Remove the current year data from predicted_nest_page
- [ ] Do we need to do this for predicted counts? Combine the two pages?
- [ ] A message in the predicted_nest_page directing them to the current nest page?  

**This currently only works for FluidPage() and not for SideBarLayout**, we'll need to redesign. 